### PR TITLE
Add Object.create bench

### DIFF
--- a/bench/object-creation.js
+++ b/bench/object-creation.js
@@ -27,6 +27,11 @@ suite.add('constructor', function allNums () {
   var obj = new MyCtor(1)
 })
 
+var literal = { x: 1 }
+suite.add('create', function allNums () {
+  var obj = Object.create(literal)
+})
+
 suite.on('cycle', () => runs = 0)
 
 suite.on('complete', require('./print'))


### PR DESCRIPTION
Node 8.2.1:

```
literal x 90,324,950 ops/sec ±1.27% (86 runs sampled)
class x 33,261,392 ops/sec ±1.50% (87 runs sampled)
constructor x 86,360,222 ops/sec ±1.48% (83 runs sampled)
create x 37,239,048 ops/sec ±1.30% (90 runs sampled)
Fastest is literal
```

Node 6.11.1:

```
literal x 107,867,654 ops/sec ±1.60% (86 runs sampled)
class x 98,524,088 ops/sec ±2.69% (82 runs sampled)
constructor x 101,653,981 ops/sec ±2.32% (81 runs sampled)
create x 13,509,253 ops/sec ±1.47% (85 runs sampled)
Fastest is literal
```