### PR TITLE
Fix benchmarks

### DIFF
--- a/bench/numbers.js
+++ b/bench/numbers.js
@@ -4,31 +4,34 @@ var benchmark = require('benchmark')
 var suite = new benchmark.Suite()
 
 function sum (base, max) {
-  var total = 0
-
-  for (var i = base; i < max; i++) {
+  var total = base
+  for (var i = base + 1; i < max; i++) {
     total += i
   }
+  return total
 }
 
 
 suite.add('sum small', function smallSum () {
   var base = 0
   var max = 65535
+  // 0 + 1 + ... + 65535 = 2147450880 < 2147483647
 
   sum(base, max)
 })
 
 suite.add('from small to big', function bigSum () {
   var base = 32768
-  var max = 98304
+  var max = 98303
+  // 32768 + 32769 + ... + 98303 = 4294934528 > 2147483647
 
   sum(base, max)
 })
 
 suite.add('all big', function bigSum () {
-  var base = 65536
-  var max = 131071
+  var base = 2147483648
+  var max = 2147549183
+  // 2147483648 > 2147483647
 
   sum(base, max)
 })

--- a/bench/object-creation.js
+++ b/bench/object-creation.js
@@ -14,17 +14,18 @@ function MyCtor (x) {
   this.x = x
 }
 
+var obj
 
 suite.add('literal', function base () {
-  var obj = { x: 1 }
+  obj = { x: 1 }
 })
 
 suite.add('class', function allNums () {
-  var obj = new MyClass(1)
+  obj = new MyClass(1)
 })
 
 suite.add('constructor', function allNums () {
-  var obj = new MyCtor(1)
+  obj = new MyCtor(1)
 })
 
 suite.on('cycle', () => runs = 0)


### PR DESCRIPTION
Addresses @jkummerow and @hashseed's comments on the blog post ([@jkummerow](https://www.nearform.com/blog/node-js-is-getting-a-new-v8-with-turbofan/#comment-3439322768),
 [@hashseed](https://www.nearform.com/blog/node-js-is-getting-a-new-v8-with-turbofan/#comment-3438859842)).

How were the charts produced? I'd like to update them as well.

- numbers.js

   On Node.js v8.2.1 with V8 5.8:

   ```
   sum small x 21,061 ops/sec ±1.68% (88 runs sampled)
   from small to big x 14,684 ops/sec ±0.50% (91 runs sampled)
   all big x 9,515 ops/sec ±0.46% (90 runs sampled)
   ```

   On Node.js v9.0.0-v8-canary20170724c045f1f8dc with V8 6.2.4:

   ```
   sum small x 16,438 ops/sec ±1.40% (86 runs sampled)
   from small to big x 14,751 ops/sec ±0.67% (90 runs sampled)
   all big x 11,993 ops/sec ±5.12% (84 runs sampled)
   ```

   Compare: ![](https://www.nearform.com/img/blog/2017/07/numbers-line.png)

- object-creation.js

   Node.js v8.2.1 with V8 5.8:

   ```
   literal x 28,455,810 ops/sec ±1.19% (83 runs sampled)
   class x 21,993,317 ops/sec ±1.13% (86 runs sampled)
   constructor x 28,093,899 ops/sec ±0.73% (82 runs sampled)
   ```

   Node.js v9.0.0-v8-canary20170724c045f1f8dc with V8 6.2.4:

   ```
   literal x 31,861,977 ops/sec ±0.88% (86 runs sampled)
   class x 32,265,246 ops/sec ±0.65% (90 runs sampled)
   constructor x 32,120,661 ops/sec ±0.99% (87 runs sampled)
   ```

   Compare: ![](https://www.nearform.com/img/blog/2017/07/object-creation-line.png)

Refs: https://github.com/nodejs/CTC/issues/155#issuecomment-318670712